### PR TITLE
Optimize nested loop efficiency in the Anomaly Attention class

### DIFF
--- a/model/attn.py
+++ b/model/attn.py
@@ -25,11 +25,11 @@ class AnomalyAttention(nn.Module):
         self.mask_flag = mask_flag
         self.output_attention = output_attention
         self.dropout = nn.Dropout(attention_dropout)
-        window_size = win_size
-        self.distances = torch.zeros((window_size, window_size)).cuda()
-        for i in range(window_size):
-            for j in range(window_size):
-                self.distances[i][j] = abs(i - j)
+        self.win_size = win_size
+
+        i = torch.arange(self.win_size).view(-1,1).cuda()
+        j = torch.arange(self.win_size).view(1,-1).cuda()
+        self.distances = torch.abs(i-j)
 
     def forward(self, queries, keys, values, sigma, attn_mask):
         B, L, H, E = queries.shape


### PR DESCRIPTION
Refactored the existing nested loop structure within the Anomaly Attention class used for finding the distance between the indexes. Replaced the original dual for-loops, which scaled with window size, with a more efficient implementation.

Performance Improvement:
- Original execution time for a window size of 250: ~50 seconds.
- New execution time for the same window size: ~0.01 seconds.

I was experimenting with different window sizes to see their effects on my dataset. However, in my current setup where I use a high-performance workstation, it started to take too much time when I increased the window size. This new approach takes much more lower time to achieve the same matrix.